### PR TITLE
Add pug

### DIFF
--- a/styles/unfancy-file-icons.less
+++ b/styles/unfancy-file-icons.less
@@ -135,7 +135,7 @@ atom-panel ul.tab-bar li.tab .title[data-name]:before {
   }
 
   // Templates
-  [data-name$='.jade']:before,
+  [data-name$='.pug']:before,
   [data-name$='.haml']:before,
   [data-name$='.hamlc']:before,
   [data-name$='.erb']:before,

--- a/styles/unfancy-file-icons.less
+++ b/styles/unfancy-file-icons.less
@@ -135,6 +135,7 @@ atom-panel ul.tab-bar li.tab .title[data-name]:before {
   }
 
   // Templates
+  [data-name$='.jade']:before,
   [data-name$='.pug']:before,
   [data-name$='.haml']:before,
   [data-name$='.hamlc']:before,


### PR DESCRIPTION
Jade got renamed to Pug because of Copyright issues. I left the Jade for older projects who haven't updated yet.
