### PR TITLE
Add icons for some files

### DIFF
--- a/styles/unfancy-file-icons.less
+++ b/styles/unfancy-file-icons.less
@@ -172,6 +172,7 @@ atom-panel ul.tab-bar li.tab .title[data-name]:before {
   [data-name$='.spectacular']:before,
   [data-name='Procfile']:before,
   [data-name='.htaccess']:before,
+  [data-name='.editorconfig']:before,
   [data-name$='.ruby-version']:before,
   [data-name^='.'][data-name$='rc']:before {
     content: '\f02f';

--- a/styles/unfancy-file-icons.less
+++ b/styles/unfancy-file-icons.less
@@ -145,6 +145,7 @@ atom-panel ul.tab-bar li.tab .title[data-name]:before {
   [data-path*='bin/'].title:before,
   [data-name$='.n']:before,
   [data-name$='.sh']:before,
+  [data-name$='.cmd']:before,
   [data-name$='.bat']:before {
     content: '\f0c8';
     color: @magenta;


### PR DESCRIPTION
Add icons for following files:
- Windows batch file (.cmd extension);
- EditorConfig configuration file.

I also noticed there is an [icon](https://octicons.github.com/icon/diff/) for diff/patch file in Octicons iconset. I'd like to add the icon to .diff and .patch files too, but I don't know what colors I should apply to these files.
